### PR TITLE
Add trkref parameters to conversations api endpoints

### DIFF
--- a/docs/reevooapi/conversation/conversation-detail.markdown
+++ b/docs/reevooapi/conversation/conversation-detail.markdown
@@ -13,14 +13,15 @@ next: conversation/conversation-create
 Returns details for a single conversation.
 
 ## URL Format
-GET /v4/conversations/{id}
+GET /v4/conversations/{id}?trkref={TRKREF}
 
 ## URL Example
-GET /v4/conversations/223049
+GET /v4/conversations/223049?trkref=D10
 
 ## Parameters
 
 {: .documentation}
+|trkref     |               |
 |id         |conversation id|
 
 

--- a/docs/reevooapi/conversation/conversation-downvote-answer.markdown
+++ b/docs/reevooapi/conversation/conversation-downvote-answer.markdown
@@ -17,14 +17,15 @@ Increments the unhelpful attribute of the answer by 1.
 </div>
 
 ## URL Format
-POST /v4/conversation_anwers/{answer_id}/increment_unhelpful
+POST /v4/conversation_anwers/{answer_id}/increment_unhelpful?trkref={TRKREF}
 
 ### Example
-POST /v4/conversation_anwers/38373/increment_unhelpful
+POST /v4/conversation_anwers/38373/increment_unhelpful?trkref=D10
 
 ### Parameters
 
 {: .documentation}
+|trkref        |                                     |
 |answer_id     |id of the conversation answer        |
 
 ## Possible responses

--- a/docs/reevooapi/conversation/conversation-downvote-question.markdown
+++ b/docs/reevooapi/conversation/conversation-downvote-question.markdown
@@ -17,15 +17,16 @@ Increments the unhelpful attribute of the question by 1.
 </div>
 
 ## URL Format
-POST /v4/conversations/{question_id}/increment_unhelpful
+POST /v4/conversations/{question_id}/increment_unhelpful?trkref={TRKREF}
 
 ### Example
-POST /v4/conversations/38373/increment_unhelpful
+POST /v4/conversations/38373/increment_unhelpful?trkref=D10
 
 ### Parameters
 
 {: .documentation}
-|question_id     |id of the conversation question        |
+|trkref          |                                |
+|question_id     |id of the conversation question |
 
 ## Possible responses
 

--- a/docs/reevooapi/conversation/conversation-upvote-answer.markdown
+++ b/docs/reevooapi/conversation/conversation-upvote-answer.markdown
@@ -17,15 +17,16 @@ Increments the helpful attribute of the answer by 1.
 </div>
 
 ## URL Format
-POST /v4/conversation_anwers/{answer_id}/increment_helpful
+POST /v4/conversation_anwers/{answer_id}/increment_helpful?trkref={TRKREF}
 
 ### Example
-POST /v4/conversation_anwers/38373/increment_helpful
+POST /v4/conversation_anwers/38373/increment_helpful?trkref=D10
 
 ### Parameters
 
 {: .documentation}
-|answer_id     |id of the conversation answer        |
+|trkref        |                              |
+|answer_id     |id of the conversation answer |
 
 ## Possible responses
 

--- a/docs/reevooapi/conversation/conversation-upvote-question.markdown
+++ b/docs/reevooapi/conversation/conversation-upvote-question.markdown
@@ -17,15 +17,16 @@ Increments the helpful attribute of the question by 1.
 </div>
 
 ## URL Format
-POST /v4/conversations/{question_id}/increment_helpful
+POST /v4/conversations/{question_id}/increment_helpful?trkref={TRKREF}
 
 ### Example
-POST /v4/conversations/38373/increment_helpful
+POST /v4/conversations/38373/increment_helpful?trkref=D10
 
 ### Parameters
 
 {: .documentation}
-|question_id     |id of the conversation question        |
+|trkref          |                                |
+|question_id     |id of the conversation question |
 
 ## Possible responses
 


### PR DESCRIPTION
Due to the changes to the way the api authentication works the TRKREF parameter is now mandatory.
