### PR TITLE
Documentatio cleanup

### DIFF
--- a/_posts/2014-08-01-easier-reevoo-assets-integration.markdown
+++ b/_posts/2014-08-01-easier-reevoo-assets-integration.markdown
@@ -19,7 +19,7 @@ As an example, looking at the current technical documentation being handed to cu
   (function() {
     var script = document.createElement('script');
     script.type = 'text/javascript';
-    script.src = 'http://cdn.mark.reevoo.com/assets/reevoo_mark.js';
+    script.src = 'https://mark.reevoo.com/assets/reevoo_mark.js';
     var s = document.getElementById('reevoomark-loader');
     s.parentNode.insertBefore(script, s);
   })();
@@ -39,7 +39,7 @@ As an example, looking at the current technical documentation being handed to cu
   (function() {
     var script = document.createElement('script');
     script.type = 'text/javascript';
-    script.src = 'http://cdn.mark.reevoo.com/assets/reevoo_mark.js';
+    script.src = 'https://mark.reevoo.com/assets/reevoo_mark.js';
     var s = document.getElementById('reevoomark-loader');
     s.parentNode.insertBefore(script, s);
   })();
@@ -61,7 +61,7 @@ What they should have included in the page in this instance if they wanted both 
   (function() {
     var script = document.createElement('script');
     script.type = 'text/javascript';
-    script.src = 'http://cdn.mark.reevoo.com/assets/reevoo_mark.js';
+    script.src = 'https://mark.reevoo.com/assets/reevoo_mark.js';
     var s = document.getElementById('reevoomark-loader');
     s.parentNode.insertBefore(script, s);
   })();

--- a/docs/reevooapi/customer-experience-review/customer-experience-review-detail.markdown
+++ b/docs/reevooapi/customer-experience-review/customer-experience-review-detail.markdown
@@ -15,12 +15,6 @@ Details for a single customer experience review.
 
 `GET /v4/customer_experience_reviews/:id?trkref=:trkref`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/customer_experience_reviews/2774063
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/customer-experience-review/customer-experience-review-list.markdown
+++ b/docs/reevooapi/customer-experience-review/customer-experience-review-list.markdown
@@ -17,12 +17,6 @@ Only published customer experience reviews will be included.
 
 `GET /v4/organisations/:trkref/customer_experience_reviews`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/customer_experience_reviews
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/organisation/organisation-detail.markdown
+++ b/docs/reevooapi/organisation/organisation-detail.markdown
@@ -16,12 +16,6 @@ retrieve information for organisations assigned to their API key.
 
 `GET /v4/organisations/:trkref`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/review/review-detail.markdown
+++ b/docs/reevooapi/review/review-detail.markdown
@@ -15,12 +15,6 @@ Details for a single review.
 
 `GET /v4/reviews/:id?trkref=:trkref`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviews/5996122
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/review/review-list.markdown
+++ b/docs/reevooapi/review/review-list.markdown
@@ -17,12 +17,6 @@ Reviews are aggregated, so the ones that have been collected for other organisat
 
 `GET /v4/organisations/:trkref/reviews?locale=:locale&sku=:sku`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviewables;locale=en-GB;sku=AIPTPDV5700/reviews
-  <strong> is deprecated. <br />Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters for non-automotive reviews
 
 {: .documentation-table}

--- a/docs/reevooapi/reviewable/reviewable-detail.markdown
+++ b/docs/reevooapi/reviewable/reviewable-detail.markdown
@@ -19,12 +19,6 @@ reviews will only be returned for the organisation's locale.
 
 `GET /v4/organisations/:trkref/reviewable?locale=:locale&sku=:sku`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviewables;locale=en-GB;sku=AIPTPDV5700
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/reviewable/reviewable-list.markdown
+++ b/docs/reevooapi/reviewable/reviewable-list.markdown
@@ -17,12 +17,6 @@ organisation.
 
 `GET /v4/organisations/:trkref/reviewables`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviewables
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ### Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/reviewable/reviewable-short-format-detail.markdown
+++ b/docs/reevooapi/reviewable/reviewable-short-format-detail.markdown
@@ -16,12 +16,6 @@ a short set of key values for the reviewable, including the review count and ave
 
 `GET /v4/organisations/:trkref/reviewable?locale=:locale&sku=:sku&format=:format`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviewables;locale=en-GB;sku=AIPTPDV5700?format=short
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ## Parameters
 
 {: .documentation-table}

--- a/docs/reevooapi/reviewable/reviewable-short-format-list.markdown
+++ b/docs/reevooapi/reviewable/reviewable-short-format-list.markdown
@@ -27,12 +27,6 @@ by this endpoint and no SKUs are specified.
 
 `GET /v4/organisations/:trkref/reviewables?format=:format&skus=:skus`
 
-<div class="warning">
-  <strong>This URL: </strong>
-  /v4/organisations;trkref=D10/reviewables?format=short
-  <strong> is deprecated. Please switch to the current URL above.</strong><br/>
-</div>
-
 ## Parameter(s)
 
 {: .documentation-table}

--- a/docs/reevoomark/embedded-conversations.markdown
+++ b/docs/reevoomark/embedded-conversations.markdown
@@ -17,7 +17,7 @@ To display embedded conversations in your website you have to
 
 2\. Include our embedded reviews CSS in your HTML header, using the HTML link below:
 {% highlight html %}
-  <link rel="stylesheet" href="//cdn.mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
+  <link rel="stylesheet" href="//mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
 {% endhighlight %}
 
 

--- a/docs/reevoomark/embedded-customer-experience-reviews.markdown
+++ b/docs/reevoomark/embedded-customer-experience-reviews.markdown
@@ -17,7 +17,7 @@ To display embedded customer experience reviews in your website you have to
 
 2\. Include our embedded reviews CSS in your HTML header, using the HTML link below:
 {% highlight html %}
-  <link rel="stylesheet" href="//cdn.mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
+  <link rel="stylesheet" href="//mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
 {% endhighlight %}
 
 

--- a/docs/reevoomark/embedded-product-reviews.markdown
+++ b/docs/reevoomark/embedded-product-reviews.markdown
@@ -18,7 +18,7 @@ To display embedded product reviews in your website you have to
 
 2\. Include our embedded reviews CSS in your HTML header, using the HTML link below:
 {% highlight html %}
-  <link rel="stylesheet" href="//cdn.mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
+  <link rel="stylesheet" href="//mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
 {% endhighlight %}
 
 3\. add the `reevoo-embedded-product-reviews` tag with `trkref="TRKREF"` and `sku="SKU"` and `per_page="PER_PAGE"` and optionally, `locale="LOCALE"` attributes

--- a/docs/reevoomark/embedded-tabbed.markdown
+++ b/docs/reevoomark/embedded-tabbed.markdown
@@ -24,7 +24,7 @@ To display embedded tabbed reviews in your website you have to
 
 2\. Include our embedded reviews CSS in your HTML header, using the HTML link below:
 {% highlight html %}
-  <link rel="stylesheet" href="//cdn.mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
+  <link rel="stylesheet" href="//mark.reevoo.com/assets/embedded_reviews.css" type="text/css" />
 {% endhighlight %}
 
 3\. Add the `reevoo-embedded-tabbed` tag with attributes. The attributes should be the same as for [Embedded Product Reviews](../embedded-product-reviews) including the optional attributes for Automotive Partners.

--- a/docs/reevoomark/getting-started.markdown
+++ b/docs/reevoomark/getting-started.markdown
@@ -31,7 +31,7 @@ For this example you need to replace ```TRKREF``` with the account code provided
     s=d.createElement('script');s.type='text/javascript';s.src=u;
     l=d.getElementById(i);l.parentNode.insertBefore(s,l);w['ReevooMarkHandlerName']=f;
     w[f]=function(){(w[f].q=w[f].q||[]).push(arguments)}
-  })(window, document, '//cdn.mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
+  })(window, document, '//mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
 </script>
 {% endhighlight %}
 

--- a/docs/reevoomark/javascript-library.markdown
+++ b/docs/reevoomark/javascript-library.markdown
@@ -20,7 +20,7 @@ The code below imports our library, but without any client specific configuratio
     s=d.createElement('script');s.type='text/javascript';s.src=u;
     l=d.getElementById(i);l.parentNode.insertBefore(s,l);w['ReevooMarkHandlerName']=f;
     w[f]=function(){(w[f].q=w[f].q||[]).push(arguments)}
-  })(window, document, '//cdn.mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
+  })(window, document, '//mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
 </script>
 {% endhighlight %}
 
@@ -31,7 +31,7 @@ HTTP
 
 {% highlight javascript %}
   ...
-  })(window, document, 'http://cdn.mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
+  })(window, document, 'http://mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
 {% endhighlight %}
 
 HTTPS
@@ -39,7 +39,7 @@ HTTPS
 
 {% highlight javascript %}
   ...
-  })(window, document, 'https://cdn.mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
+  })(window, document, 'https://mark.reevoo.com/assets/reevoo_mark.js', 'reevoomark-loader', 'reevooMark');
 {% endhighlight %}
 
 The reason why we ask you to load our JavaScript library this way is that it avoids blocking your page on first load. It also ensures if we are experiencing any issues regarding our services, your pages will not be blocked. It does, however, add some complexity to using the library as you cannot guarantee that our library will be loaded, or when. Thus we provide callbacks (shown in the next section) to allow you to ensure commands are called once our library is loaded onto the page.


### PR DESCRIPTION
- Remove references to “cdn.mark.reevoo.com” and change them to “mark.reevoo.com”.

- Remove reference to deprecated url format from api endpoints.

NOTE: I’ll do the same changes in the new documentation site as well.